### PR TITLE
Fix: Added headroom for request size for upserting embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __pycache__
 
 # deepeval
 .deepeval
+
+# vscode
+.vscode

--- a/backend/app/rag/routes.py
+++ b/backend/app/rag/routes.py
@@ -4,11 +4,11 @@ from app.utils import verify_auth_header
 from app.extensions import embedding_client
 from pinecone import Pinecone
 from pinecone.exceptions import PineconeException
-from langchain.schema import Document
-from langchain_pinecone import PineconeVectorStore
+# from pinecone.grpc import PineconeGRPC as Pinecone
 from app.config import Config
 from langchain_voyageai import VoyageAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
+import uuid
 pinecone_api_key = Config.PINECONE_API_KEY
 
 
@@ -35,32 +35,34 @@ def generate_embeddings():
         chunks = splitter.split_text(scraped_content)
         print(f"Num of chunks: {len(chunks)}")
 
+        # Initalize Pinecone
+        pc = Pinecone(api_key=pinecone_api_key)
+
+        # Connect to Pinecone index
+        pinecone_index = pc.Index("llmeval")
+
+
         
-        documents = []
+        vectors = []
         for sent_index, sent in enumerate(chunks):
             source = f"""{url} sentence #: {sent_index}"""
-            doc = Document(
-                page_content=sent,
-                metadata={
+            nId = uuid.uuid4()
+            raw_query_embedding = embedding_client.embed(texts=sent, model="voyage-3-lite").embeddings[0]
+            oth = {
+                "id": str(nId),
+                "values": raw_query_embedding,
+                "metadata": {
+                    "text": sent,
                     "source": source,
                     "chunk_index": sent_index,
                     "total_chunks": len(chunks)
                 }
-            )
-            documents.append(doc)
+            }
+            vectors.append(oth)
 
-        for doc in documents:
-            print(f"doc: {doc}\n")
+        print(f"number of vectors: {len(vectors)}")
+        pinecone_index.upsert(vectors=vectors, namespace=url, batch_size=96)
 
-        print(f"number of documents: {len(documents)}")
-
-        model_name = "voyage-3-lite"  # You can choose a different model
-        vectorstore = PineconeVectorStore.from_documents(
-            documents=documents,
-            embedding=VoyageAIEmbeddings(model=model_name, api_key=Config.VOYAGE_AI_KEY),
-            index_name="llmeval",
-            namespace=url
-        )
 
         return make_response("Successfully embedded content", 200)
     except (ValueError, TypeError) as e:
@@ -99,7 +101,7 @@ def rag_retrieve():
         pinecone_index = pc.Index("llmeval")
 
         # top_matches = pinecone_index.query(vector=raw_query_embedding.tolist(), top_k=5, include_metadata=True, namespace=url)
-        top_matches = pinecone_index.query(vector=raw_query_embedding, top_k=3, include_metadata=True, namespace=url)
+        top_matches = pinecone_index.query(vector=raw_query_embedding[0], top_k=3, include_metadata=True, namespace=url)
         
 
         print("\n\n\n-------------Matches--------------\n\n\n")

--- a/backend/app/rag/routes.py
+++ b/backend/app/rag/routes.py
@@ -27,12 +27,14 @@ def generate_embeddings():
 
 
         splitter = RecursiveCharacterTextSplitter(
-            chunk_size=512,
-            chunk_overlap=20,
+            chunk_size=1024,
+            chunk_overlap=100,
             separators=["\n\n", "\n", ".", " ", ""]
         )
 
         chunks = splitter.split_text(scraped_content)
+        print(f"Num of chunks: {len(chunks)}")
+
         
         documents = []
         for sent_index, sent in enumerate(chunks):
@@ -42,11 +44,15 @@ def generate_embeddings():
                 metadata={
                     "source": source,
                     "chunk_index": sent_index,
-                    "chunk_length": len(sent),
                     "total_chunks": len(chunks)
                 }
             )
             documents.append(doc)
+
+        for doc in documents:
+            print(f"doc: {doc}\n")
+
+        print(f"number of documents: {len(documents)}")
 
         model_name = "voyage-3-lite"  # You can choose a different model
         vectorstore = PineconeVectorStore.from_documents(

--- a/backend/app/rag/routes.py
+++ b/backend/app/rag/routes.py
@@ -4,9 +4,7 @@ from app.utils import verify_auth_header
 from app.extensions import embedding_client
 from pinecone import Pinecone
 from pinecone.exceptions import PineconeException
-# from pinecone.grpc import PineconeGRPC as Pinecone
 from app.config import Config
-from langchain_voyageai import VoyageAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 import uuid
 pinecone_api_key = Config.PINECONE_API_KEY
@@ -42,15 +40,15 @@ def generate_embeddings():
         pinecone_index = pc.Index("llmeval")
 
 
-        
+        values = embedding_client.embed(texts=chunks, model="voyage-3-lite").embeddings
+
         vectors = []
         for sent_index, sent in enumerate(chunks):
             source = f"""{url} sentence #: {sent_index}"""
             nId = uuid.uuid4()
-            raw_query_embedding = embedding_client.embed(texts=sent, model="voyage-3-lite").embeddings[0]
             oth = {
                 "id": str(nId),
-                "values": raw_query_embedding,
+                "values": values[sent_index],
                 "metadata": {
                     "text": sent,
                     "source": source,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the RAG embedding flow to bypass LangChain’s Pinecone vectorstore wrapper and instead upsert vectors directly via the Pinecone Python SDK (including larger text chunks and a fixed upsert batch size to avoid request-size limits). It also updates the retrieval query to pass a single embedding vector into Pinecone’s `query` call.

Main issue to address before merge: the retrieval embedding call currently uses `texts=prompt` where `prompt` is a string, and then indexes `[0]` before querying Pinecone. Depending on the VoyageAI client return type, this can produce an invalid vector shape (or crash), causing retrieval to fail at runtime.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but retrieval may break at runtime due to an embedding shape/type mismatch.
- The changes are localized and straightforward, but `rag_retrieve` appears to pass an incorrectly shaped vector into Pinecone query depending on the embedding client’s API behavior, which would cause request failures in the primary RAG path.
- backend/app/rag/routes.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Adds .vscode to ignores and fixes newline at EOF; no behavioral impact. |
| backend/app/rag/routes.py | Reworks embedding upsert to use Pinecone SDK directly and adjusts chunking; fixes/changes query vector usage but current prompt embedding call likely passes wrong type/shape to Pinecone query. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->